### PR TITLE
fix(reduction): fix reduction calculated with unlimited precision but printed out only 2 digits

### DIFF
--- a/src/details.rs
+++ b/src/details.rs
@@ -225,14 +225,14 @@ mod tests {
         .with_description("Handbuch zur Schraube")
         .with_reduction(ReductionListLineItem::new(
             dec!(5),
-            ReductionAndSurchargeValue::Amount(dec!(2)),
+            ReductionAndSurchargeValue::Amount(dec!(2.3399)),
         ))
         .as_xml()
         .to_string();
 
         assert_eq!(
             result,
-            "<ListLineItem><Description>Handbuch zur Schraube</Description><Quantity Unit=\"STK\">1.0000</Quantity><UnitPrice>5.0000</UnitPrice><ReductionAndSurchargeListLineItemDetails><ReductionListLineItem><BaseAmount>5.00</BaseAmount><Amount>2.00</Amount></ReductionListLineItem></ReductionAndSurchargeListLineItemDetails><TaxItem><TaxableAmount>3.00</TaxableAmount><TaxPercent TaxCategoryCode=\"AA\">10</TaxPercent><TaxAmount>0.30</TaxAmount></TaxItem><LineItemAmount>3.00</LineItemAmount></ListLineItem>"
+            "<ListLineItem><Description>Handbuch zur Schraube</Description><Quantity Unit=\"STK\">1.0000</Quantity><UnitPrice>5.0000</UnitPrice><ReductionAndSurchargeListLineItemDetails><ReductionListLineItem><BaseAmount>5.00</BaseAmount><Amount>2.34</Amount></ReductionListLineItem></ReductionAndSurchargeListLineItemDetails><TaxItem><TaxableAmount>2.66</TaxableAmount><TaxPercent TaxCategoryCode=\"AA\">10</TaxPercent><TaxAmount>0.27</TaxAmount></TaxItem><LineItemAmount>2.66</LineItemAmount></ListLineItem>"
         );
     }
 

--- a/src/reduction_and_surcharge.rs
+++ b/src/reduction_and_surcharge.rs
@@ -29,10 +29,12 @@ impl<'a> ReductionAndSurchargeListLineItemBase<'a> {
     fn sum(&self) -> Decimal {
         match self.value {
             ReductionAndSurchargeValue::Percentage(percentage) => {
-                self.base_amount * percentage / Decimal::ONE_HUNDRED
+                (self.base_amount * percentage / Decimal::ONE_HUNDRED).clone_with_scale(2)
             }
-            ReductionAndSurchargeValue::Amount(amount) => amount,
-            ReductionAndSurchargeValue::PercentageAndAmount(_, amount) => amount,
+            ReductionAndSurchargeValue::Amount(amount) => amount.clone_with_scale(2),
+            ReductionAndSurchargeValue::PercentageAndAmount(_, amount) => {
+                amount.clone_with_scale(2)
+            }
         }
     }
 
@@ -242,7 +244,7 @@ mod tests {
             .with_reduction(
                 ReductionListLineItem::new(
                     dec!(100),
-                    ReductionAndSurchargeValue::PercentageAndAmount(dec!(2), dec!(3)),
+                    ReductionAndSurchargeValue::PercentageAndAmount(dec!(2), dec!(3.4599)),
                 )
                 .with_comment("reduction"),
             )
@@ -251,7 +253,7 @@ mod tests {
 
         assert_eq!(
             result,
-            "<ReductionAndSurchargeListLineItemDetails><ReductionListLineItem><BaseAmount>100.00</BaseAmount><Percentage>2.00</Percentage><Amount>3.00</Amount><Comment>reduction</Comment></ReductionListLineItem></ReductionAndSurchargeListLineItemDetails>"
+            "<ReductionAndSurchargeListLineItemDetails><ReductionListLineItem><BaseAmount>100.00</BaseAmount><Percentage>2.00</Percentage><Amount>3.46</Amount><Comment>reduction</Comment></ReductionListLineItem></ReductionAndSurchargeListLineItemDetails>"
         );
     }
 }


### PR DESCRIPTION
it now calculates with only 2 digits after decimal point